### PR TITLE
Generate metal repo and add initial validators and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This file is for unifying the coding style for different editors and IDEs
+# See editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bower_components
+build
+coverage
+node_modules
+/lib

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,32 @@
+{
+  "asi": false,
+  "bitwise": false,
+  "browser": true,
+  "curly": true,
+  "eqeqeq": true,
+  "esnext": true,
+  "evil": false,
+  "forin": false,
+  "globals": {
+    "IncrementalDOM": true,
+    "soy": true,
+    "soydata": true
+  },
+  "immed": true,
+  "indent": 2,
+  "lastsemic": false,
+  "maxdepth": false,
+  "multistr": false,
+  "newcap": true,
+  "noarg": true,
+  "node": true,
+  "onevar": false,
+  "quotmark": "single",
+  "proto": true,
+  "regexp": true,
+  "smarttabs": true,
+  "strict": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+# Software License Agreement (BSD License)
+
+Copyright (c) 2014, Liferay Inc.
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* The name of Liferay Inc. may not be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Liferay Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/env/test/node.js
+++ b/env/test/node.js
@@ -1,0 +1,3 @@
+var assert = require('assert');
+
+global.assert = assert;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var metal = require('gulp-metal');
+
+metal.registerTasks({
+	bundleCssFileName: 'metal-state-validators.css',
+	bundleFileName: 'metal-state-validators.js',
+	moduleName: 'metal-metal-state-validators',
+	noSoy: true,
+	testNodeSrc: [
+		'env/test/node.js',
+		'test/**/*.js'
+	]
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "metal-state-validators",
+  "version": "0.0.0",
+  "description": "Utility class with helpers for creating validators for Metal.js state",
+  "license": "BSD",
+  "repository": "metal/metal-state-validators",
+  "engines": {
+    "node": ">=0.12.0",
+    "npm": ">=3.0.0"
+  },
+  "main": "src/type.js",
+  "browser": "lib/type.js",
+  "files": [
+    "lib",
+    "src",
+    "test"
+  ],
+  "scripts": {
+    "build": "gulp build",
+    "compile": "babel --presets es2015 -d lib/ src/",
+    "publish": "npm run compile",
+    "test": "gulp test",
+    "watch": "gulp build:watch"
+  },
+  "keywords": [
+    "metal"
+  ],
+  "dependencies": {
+    "metal": "^1.0.0-rc.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.4.5",
+    "babel-preset-es2015": "^6.3.13",
+    "gulp": "^3.8.11",
+    "gulp-metal": "^1.0.0",
+    "metal": "^1.0.0-rc.2"
+  }
+}

--- a/src/type.js
+++ b/src/type.js
@@ -4,64 +4,38 @@ import { core } from 'metal';
 
 const validators = {
 	any: () => true,
-	array: validateType('array'),
-	bool: validateType('boolean'),
-	func: validateType('function'),
-	number: validateType('number'),
-	object: validateType('object'),
-	string: validateType('string'),
+	array: primitiveTypeValidatorFactory('array'),
+	bool: primitiveTypeValidatorFactory('boolean'),
+	func: primitiveTypeValidatorFactory('function'),
+	number: primitiveTypeValidatorFactory('number'),
+	object: primitiveTypeValidatorFactory('object'),
+	string: primitiveTypeValidatorFactory('string'),
 
-	arrayOf: (validator) => {
-		return composeValidator(
-			arrayOfValidatorFactory,
-			validator
-		);
-	},
-	instanceOf: (expectedClass) => {
-		return composeValidator(
-			instanceOfValidatorFactory,
-			expectedClass
-		);
-	},
-	objectOf: (validator) => {
-		return composeValidator(
-			objectOfValidatorFactory,
-			validator
-		);
-	},
-	oneOfType: (arrayOfTypeValidators) => {
-		return composeValidator(
-			oneOfTypeValidatorFactory,
-			arrayOfTypeValidators
-		);
-	},
-	shape: (shape) => {
-		return composeValidator(
-			shapeValidatorFactory,
-			shape
-		);
-	}
+	arrayOf: arrayOfValidatorFactory,
+	instanceOf: instanceOfValidatorFactory,
+	objectOf: objectOfValidatorFactory,
+	oneOfType: oneOfTypeValidatorFactory,
+	shapeOf: shapeOfValidatorFactory
 };
 
 /**
  * Creates a validator that checks the values of an array against a type.
  * @param {!function} validator Type validator to check each index against.
- * @param {boolean} noWarn Determines whether warnings should be emitted.
  * @return {function} Validator.
  */
-function arrayOfValidatorFactory(validator, noWarn) {
+function arrayOfValidatorFactory(validator) {
 	return (value, name, context) => {
 		if (!Array.isArray(value)) {
-			return warning('Expected an array.', name, context, noWarn);
+			return composeError('Expected an array.', name, context);
 		} else {
 			const testArray = value.every(
 				item => {
-					return validator.noWarn(item, name);
+					return !(validator(item, name) instanceof Error);
 				}
 			);
 
 			if (!testArray) {
-				return warning('Expected an array of single type', name, context, noWarn);
+				return composeError('Expected an array of single type', name, context);
 			}
 		}
 
@@ -70,32 +44,20 @@ function arrayOfValidatorFactory(validator, noWarn) {
 }
 
 /**
- * Creates two functions, one that emits warnings and one that does not.
- * @param {!function} validatorFactory Function that creates a validator.
- * @param factoryArg Argument that is passed to the factory.
- * @return {function} Validator.
- */
-function composeValidator(validatorFactory, factoryArg) {
-	const validator = validatorFactory(factoryArg);
-	validator.noWarn = validatorFactory(factoryArg, true);
-
-	return validator;
-}
-
-/**
- * Emits a warning to the console.
+ * Composes a warning a warning message.
  * @param {!string} error Error message to display to console.
  * @param {string} name Name of state property that is giving the error.
  * @param {object} context.
+ * @return {Error}
  */
-function emitWarning(error, name, context) {
+function composeError(error, name, context) {
 	const componentName = context ? core.getFunctionName(context) : null;
 	const parentComponent = context && context.getRenderer ? context.getRenderer().lastParentComponent_ : null;
 	const parentComponentName = parentComponent ? core.getFunctionName(parentComponent) : null;
 
 	const location = parentComponentName ? `Check render method of '${parentComponentName}'.` : '';
 
-	console.error(`Warning: Invalid state passed to '${name}'. ${error} Passed to '${componentName}'. ${location}`);
+	return new Error(`Warning: Invalid state passed to '${name}'. ${error} Passed to '${componentName}'. ${location}`);
 }
 
 /**
@@ -115,13 +77,12 @@ function getStateType(value) {
 /**
  * Creates a validator that compares a value to a specific class.
  * @param {!function} expectedClass Class to check value against.
- * @param {boolean} noWarn Determines whether warnings should be emitted.
  * @return {function} Validator.
  */
-function instanceOfValidatorFactory(expectedClass, noWarn) {
+function instanceOfValidatorFactory(expectedClass) {
 	return (value, name, context) => {
 		if (!(value instanceof expectedClass)) {
-			return warning(`Expected instance of ${expectedClass}`, name, context, noWarn);
+			return composeError(`Expected instance of ${expectedClass}`, name, context);
 		}
 
 		return true;
@@ -131,19 +92,18 @@ function instanceOfValidatorFactory(expectedClass, noWarn) {
 /**
  * Creates a validator that checks the values of an object against a type.
  * @param {!function} typeValidator Validator to check value against.
- * @param {boolean} noWarn Determines whether warnings should be emitted.
  * @return {function} Validator.
  */
-function objectOfValidatorFactory(typeValidator, noWarn) {
+function objectOfValidatorFactory(typeValidator) {
 	return (value, name, context) => {
 		let success = true;
 
 		for (let key in value) {
-			success = typeValidator.noWarn(value[key], null);
+			success = !(typeValidator(value[key], null) instanceof Error);
 		}
 
 		if (!success) {
-			return warning('Expected object of one type', name, context, noWarn);
+			return composeError('Expected object of one type', name, context);
 		}
 
 		return true;
@@ -153,39 +113,37 @@ function objectOfValidatorFactory(typeValidator, noWarn) {
 /**
  * Creates a validator that checks a value against multiple types and only has to pass one.
  * @param {!array} arrayOfTypeValidators Array of validators to check value against.
- * @param {boolean} noWarn Determines whether warnings should be emitted.
  * @return {function} Validator.
  */
-function oneOfTypeValidatorFactory(arrayOfTypeValidators, noWarn) {
+function oneOfTypeValidatorFactory(arrayOfTypeValidators) {
 	if (!Array.isArray(arrayOfTypeValidators)) {
-		warning('Expected an array.', null, null, noWarn);
+		return (value, name, context) => composeError('Expected an array.', name, context);
 	}
 
 	return (value, name, context) => {
 		for (let i = 0; i < arrayOfTypeValidators.length; i++) {
 			const validator = arrayOfTypeValidators[i];
 
-			if (validator.noWarn(value, name)) {
+			if (!(validator(value, name) instanceof Error)) {
 				return true;
 			}
 		}
 
-		return warning('Expected one of given types.', name, context, noWarn);
+		return composeError('Expected one of given types.', name, context);
 	};
 }
 
 /**
  * Creates a validator that checks against a specific primitive type.
  * @param {!string} expectedType Type to check against.
- * @param {boolean} noWarn Determines whether warnings should be emitted.
  * @return {function} Validator.
  */
-function primitiveTypeValidatorFactory(expectedType, noWarn) {
+function primitiveTypeValidatorFactory(expectedType) {
 	return (value, name, context) => {
 		const type = getStateType(value);
 
 		if (type !== expectedType) {
-			return warning(`Expected type ${expectedType}`, name, context, noWarn);
+			return composeError(`Expected type '${expectedType}'`, name, context);
 		}
 
 		return true;
@@ -195,12 +153,11 @@ function primitiveTypeValidatorFactory(expectedType, noWarn) {
 /**
  * Creates a validator that checks the shape of an object.
  * @param {!object} shape An object containing type validators for each key.
- * @param {boolean} noWarn Determines whether warnings should be emitted.
  * @return {function} Validator.
  */
-function shapeValidatorFactory(shape, noWarn) {
+function shapeOfValidatorFactory(shape) {
 	if (getStateType(shape) !== 'object') {
-		warning(`Expected an object`, null, null, noWarn);
+		return (value, name, context) => composeError(`Expected an object`, name, context);
 	}
 
 	return (value, name, context) => {
@@ -208,42 +165,13 @@ function shapeValidatorFactory(shape, noWarn) {
 			const validator = shape[key];
 			const valueForKey = value[key];
 
-			if (valueForKey && !validator.noWarn(valueForKey, null)) {
-				return warning('Expected object with a specific shape', name, context, noWarn);
+			if (validator(valueForKey, null) instanceof Error) {
+				return composeError('Expected object with a specific shape', name, context);
 			}
 		}
 
 		return true;
 	};
-}
-
-/**
- * Creates a composed validator that checks against a certain type.
- * @param {!string} type Type to check against.
- * @return {function} A composed validator with both a warn and noWarn function.
- */
-function validateType(type) {
-	return composeValidator(
-		primitiveTypeValidatorFactory,
-		type
-	);
-}
-
-/**
- * Determines what to return and when if a warning should be emitted.
- * @param {!string} message Error message to emit.
- * @param {string} name Name of state key.
- * @param {object} context.
- * @param {boolean} noWarn Determines whether emitWarning should be run.
- */
-function warning(message, name, context, noWarn) {
-	if (noWarn) {
-		return null;
-	} else {
-		emitWarning(message, name, context);
-	}
-
-	return true;
 }
 
 export default validators;

--- a/src/type.js
+++ b/src/type.js
@@ -2,6 +2,10 @@
 
 import { core } from 'metal';
 
+/**
+ * Provides access to various type validators that will return an
+ * instance of Error when validation fails.
+ */
 const validators = {
 	any: () => true,
 	array: validateType('array'),
@@ -13,8 +17,8 @@ const validators = {
 
 	/**
 	 * Creates a validator that checks the values of an array against a type.
-	 * @param {!function} validator Type validator to check each index against.
-	 * @return {function} Validator.
+	 * @param {function()} validator Type validator to check each index against.
+	 * @return {function()} Validator.
 	 */
 	arrayOf: function(validator) {
 		return (value, name, context) => {
@@ -38,8 +42,8 @@ const validators = {
 
 	/**
 	 * Creates a validator that compares a value to a specific class.
-	 * @param {!function} expectedClass Class to check value against.
-	 * @return {function} Validator.
+	 * @param {function()} expectedClass Class to check value against.
+	 * @return {function()} Validator.
 	 */
 	instanceOf: function(expectedClass) {
 		return (value, name, context) => {
@@ -53,8 +57,8 @@ const validators = {
 
 	/**
 	 * Creates a validator that checks the values of an object against a type.
-	 * @param {!function} typeValidator Validator to check value against.
-	 * @return {function} Validator.
+	 * @param {function()} typeValidator Validator to check value against.
+	 * @return {function()} Validator.
 	 */
 	objectOf: function(typeValidator) {
 		return (value, name, context) => {
@@ -74,8 +78,8 @@ const validators = {
 
 	/**
 	 * Creates a validator that checks a value against multiple types and only has to pass one.
-	 * @param {!array} arrayOfTypeValidators Array of validators to check value against.
-	 * @return {function} Validator.
+	 * @param {!Array} arrayOfTypeValidators Array of validators to check value against.
+	 * @return {function()} Validator.
 	 */
 	oneOfType: function(arrayOfTypeValidators) {
 		if (!Array.isArray(arrayOfTypeValidators)) {
@@ -97,8 +101,8 @@ const validators = {
 
 	/**
 	 * Creates a validator that checks the shape of an object.
-	 * @param {!object} shape An object containing type validators for each key.
-	 * @return {function} Validator.
+	 * @param {!Object} shape An object containing type validators for each key.
+	 * @return {function()} Validator.
 	 */
 	shapeOf: function(shape) {
 		if (getStateType(shape) !== 'object') {
@@ -122,10 +126,10 @@ const validators = {
 
 /**
  * Composes a warning a warning message.
- * @param {!string} error Error message to display to console.
- * @param {string} name Name of state property that is giving the error.
- * @param {object} context.
- * @return {Error}
+ * @param {string} error Error message to display to console.
+ * @param {?string} name Name of state property that is giving the error.
+ * @param {Object} context.
+ * @return {!Error} Instance of Error class.
  */
 function composeError(error, name, context) {
 	const componentName = context ? core.getFunctionName(context) : null;
@@ -139,7 +143,7 @@ function composeError(error, name, context) {
 
 /**
  * Checks type of given value.
- * @param value Any value.
+ * @param {*} value Any value.
  * @return {string} Type of value.
  */
 function getStateType(value) {
@@ -153,8 +157,8 @@ function getStateType(value) {
 
 /**
  * Creates a validator that checks against a specific primitive type.
- * @param {!string} expectedType Type to check against.
- * @return {function} Validator.
+ * @param {string} expectedType Type to check against.
+ * @return {function()} Validator.
  */
 function validateType(expectedType) {
 	return (value, name, context) => {

--- a/src/type.js
+++ b/src/type.js
@@ -4,44 +4,121 @@ import { core } from 'metal';
 
 const validators = {
 	any: () => true,
-	array: primitiveTypeValidatorFactory('array'),
-	bool: primitiveTypeValidatorFactory('boolean'),
-	func: primitiveTypeValidatorFactory('function'),
-	number: primitiveTypeValidatorFactory('number'),
-	object: primitiveTypeValidatorFactory('object'),
-	string: primitiveTypeValidatorFactory('string'),
+	array: validateType('array'),
+	bool: validateType('boolean'),
+	func: validateType('function'),
+	number: validateType('number'),
+	object: validateType('object'),
+	string: validateType('string'),
 
-	arrayOf: arrayOfValidatorFactory,
-	instanceOf: instanceOfValidatorFactory,
-	objectOf: objectOfValidatorFactory,
-	oneOfType: oneOfTypeValidatorFactory,
-	shapeOf: shapeOfValidatorFactory
-};
+	/**
+	 * Creates a validator that checks the values of an array against a type.
+	 * @param {!function} validator Type validator to check each index against.
+	 * @return {function} Validator.
+	 */
+	arrayOf: function(validator) {
+		return (value, name, context) => {
+			if (!Array.isArray(value)) {
+				return composeError('Expected an array.', name, context);
+			} else {
+				const testArray = value.every(
+					item => {
+						return !(validator(item, name) instanceof Error);
+					}
+				);
 
-/**
- * Creates a validator that checks the values of an array against a type.
- * @param {!function} validator Type validator to check each index against.
- * @return {function} Validator.
- */
-function arrayOfValidatorFactory(validator) {
-	return (value, name, context) => {
-		if (!Array.isArray(value)) {
-			return composeError('Expected an array.', name, context);
-		} else {
-			const testArray = value.every(
-				item => {
-					return !(validator(item, name) instanceof Error);
+				if (!testArray) {
+					return composeError('Expected an array of single type', name, context);
 				}
-			);
-
-			if (!testArray) {
-				return composeError('Expected an array of single type', name, context);
 			}
+
+			return true;
+		};
+	},
+
+	/**
+	 * Creates a validator that compares a value to a specific class.
+	 * @param {!function} expectedClass Class to check value against.
+	 * @return {function} Validator.
+	 */
+	instanceOf: function(expectedClass) {
+		return (value, name, context) => {
+			if (!(value instanceof expectedClass)) {
+				return composeError(`Expected instance of ${expectedClass}`, name, context);
+			}
+
+			return true;
+		};
+	},
+
+	/**
+	 * Creates a validator that checks the values of an object against a type.
+	 * @param {!function} typeValidator Validator to check value against.
+	 * @return {function} Validator.
+	 */
+	objectOf: function(typeValidator) {
+		return (value, name, context) => {
+			let success = true;
+
+			for (let key in value) {
+				success = !(typeValidator(value[key], null) instanceof Error);
+			}
+
+			if (!success) {
+				return composeError('Expected object of one type', name, context);
+			}
+
+			return true;
+		};
+	},
+
+	/**
+	 * Creates a validator that checks a value against multiple types and only has to pass one.
+	 * @param {!array} arrayOfTypeValidators Array of validators to check value against.
+	 * @return {function} Validator.
+	 */
+	oneOfType: function(arrayOfTypeValidators) {
+		if (!Array.isArray(arrayOfTypeValidators)) {
+			return (value, name, context) => composeError('Expected an array.', name, context);
 		}
 
-		return true;
-	};
-}
+		return (value, name, context) => {
+			for (let i = 0; i < arrayOfTypeValidators.length; i++) {
+				const validator = arrayOfTypeValidators[i];
+
+				if (!(validator(value, name) instanceof Error)) {
+					return true;
+				}
+			}
+
+			return composeError('Expected one of given types.', name, context);
+		};
+	},
+
+	/**
+	 * Creates a validator that checks the shape of an object.
+	 * @param {!object} shape An object containing type validators for each key.
+	 * @return {function} Validator.
+	 */
+	shapeOf: function(shape) {
+		if (getStateType(shape) !== 'object') {
+			return (value, name, context) => composeError(`Expected an object`, name, context);
+		}
+
+		return (value, name, context) => {
+			for (let key in shape) {
+				const validator = shape[key];
+				const valueForKey = value[key];
+
+				if (validator(valueForKey, null) instanceof Error) {
+					return composeError('Expected object with a specific shape', name, context);
+				}
+			}
+
+			return true;
+		};
+	}
+};
 
 /**
  * Composes a warning a warning message.
@@ -75,99 +152,16 @@ function getStateType(value) {
 }
 
 /**
- * Creates a validator that compares a value to a specific class.
- * @param {!function} expectedClass Class to check value against.
- * @return {function} Validator.
- */
-function instanceOfValidatorFactory(expectedClass) {
-	return (value, name, context) => {
-		if (!(value instanceof expectedClass)) {
-			return composeError(`Expected instance of ${expectedClass}`, name, context);
-		}
-
-		return true;
-	};
-}
-
-/**
- * Creates a validator that checks the values of an object against a type.
- * @param {!function} typeValidator Validator to check value against.
- * @return {function} Validator.
- */
-function objectOfValidatorFactory(typeValidator) {
-	return (value, name, context) => {
-		let success = true;
-
-		for (let key in value) {
-			success = !(typeValidator(value[key], null) instanceof Error);
-		}
-
-		if (!success) {
-			return composeError('Expected object of one type', name, context);
-		}
-
-		return true;
-	};
-}
-
-/**
- * Creates a validator that checks a value against multiple types and only has to pass one.
- * @param {!array} arrayOfTypeValidators Array of validators to check value against.
- * @return {function} Validator.
- */
-function oneOfTypeValidatorFactory(arrayOfTypeValidators) {
-	if (!Array.isArray(arrayOfTypeValidators)) {
-		return (value, name, context) => composeError('Expected an array.', name, context);
-	}
-
-	return (value, name, context) => {
-		for (let i = 0; i < arrayOfTypeValidators.length; i++) {
-			const validator = arrayOfTypeValidators[i];
-
-			if (!(validator(value, name) instanceof Error)) {
-				return true;
-			}
-		}
-
-		return composeError('Expected one of given types.', name, context);
-	};
-}
-
-/**
  * Creates a validator that checks against a specific primitive type.
  * @param {!string} expectedType Type to check against.
  * @return {function} Validator.
  */
-function primitiveTypeValidatorFactory(expectedType) {
+function validateType(expectedType) {
 	return (value, name, context) => {
 		const type = getStateType(value);
 
 		if (type !== expectedType) {
 			return composeError(`Expected type '${expectedType}'`, name, context);
-		}
-
-		return true;
-	};
-}
-
-/**
- * Creates a validator that checks the shape of an object.
- * @param {!object} shape An object containing type validators for each key.
- * @return {function} Validator.
- */
-function shapeOfValidatorFactory(shape) {
-	if (getStateType(shape) !== 'object') {
-		return (value, name, context) => composeError(`Expected an object`, name, context);
-	}
-
-	return (value, name, context) => {
-		for (let key in shape) {
-			const validator = shape[key];
-			const valueForKey = value[key];
-
-			if (validator(valueForKey, null) instanceof Error) {
-				return composeError('Expected object with a specific shape', name, context);
-			}
 		}
 
 		return true;

--- a/src/type.js
+++ b/src/type.js
@@ -1,0 +1,249 @@
+'use strict';
+
+import { core } from 'metal';
+
+const validators = {
+	any: () => true,
+	array: validateType('array'),
+	bool: validateType('boolean'),
+	func: validateType('function'),
+	number: validateType('number'),
+	object: validateType('object'),
+	string: validateType('string'),
+
+	arrayOf: (validator) => {
+		return composeValidator(
+			arrayOfValidatorFactory,
+			validator
+		);
+	},
+	instanceOf: (expectedClass) => {
+		return composeValidator(
+			instanceOfValidatorFactory,
+			expectedClass
+		);
+	},
+	objectOf: (validator) => {
+		return composeValidator(
+			objectOfValidatorFactory,
+			validator
+		);
+	},
+	oneOfType: (arrayOfTypeValidators) => {
+		return composeValidator(
+			oneOfTypeValidatorFactory,
+			arrayOfTypeValidators
+		);
+	},
+	shape: (shape) => {
+		return composeValidator(
+			shapeValidatorFactory,
+			shape
+		);
+	}
+};
+
+/**
+ * Creates a validator that checks the values of an array against a type.
+ * @param {!function} validator Type validator to check each index against.
+ * @param {boolean} noWarn Determines whether warnings should be emitted.
+ * @return {function} Validator.
+ */
+function arrayOfValidatorFactory(validator, noWarn) {
+	return (value, name, context) => {
+		if (!Array.isArray(value)) {
+			return warning('Expected an array.', name, context, noWarn);
+		} else {
+			const testArray = value.every(
+				item => {
+					return validator.noWarn(item, name);
+				}
+			);
+
+			if (!testArray) {
+				return warning('Expected an array of single type', name, context, noWarn);
+			}
+		}
+
+		return true;
+	};
+}
+
+/**
+ * Creates two functions, one that emits warnings and one that does not.
+ * @param {!function} validatorFactory Function that creates a validator.
+ * @param factoryArg Argument that is passed to the factory.
+ * @return {function} Validator.
+ */
+function composeValidator(validatorFactory, factoryArg) {
+	const validator = validatorFactory(factoryArg);
+	validator.noWarn = validatorFactory(factoryArg, true);
+
+	return validator;
+}
+
+/**
+ * Emits a warning to the console.
+ * @param {!string} error Error message to display to console.
+ * @param {string} name Name of state property that is giving the error.
+ * @param {object} context.
+ */
+function emitWarning(error, name, context) {
+	const componentName = context ? core.getFunctionName(context) : null;
+	const parentComponent = context && context.getRenderer ? context.getRenderer().lastParentComponent_ : null;
+	const parentComponentName = parentComponent ? core.getFunctionName(parentComponent) : null;
+
+	const location = parentComponentName ? `Check render method of '${parentComponentName}'.` : '';
+
+	console.error(`Warning: Invalid state passed to '${name}'. ${error} Passed to '${componentName}'. ${location}`);
+}
+
+/**
+ * Checks type of given value.
+ * @param value Any value.
+ * @return {string} Type of value.
+ */
+function getStateType(value) {
+	const stateType = typeof value;
+	if (Array.isArray(value)) {
+		return 'array';
+	}
+
+	return stateType;
+}
+
+/**
+ * Creates a validator that compares a value to a specific class.
+ * @param {!function} expectedClass Class to check value against.
+ * @param {boolean} noWarn Determines whether warnings should be emitted.
+ * @return {function} Validator.
+ */
+function instanceOfValidatorFactory(expectedClass, noWarn) {
+	return (value, name, context) => {
+		if (!(value instanceof expectedClass)) {
+			return warning(`Expected instance of ${expectedClass}`, name, context, noWarn);
+		}
+
+		return true;
+	};
+}
+
+/**
+ * Creates a validator that checks the values of an object against a type.
+ * @param {!function} typeValidator Validator to check value against.
+ * @param {boolean} noWarn Determines whether warnings should be emitted.
+ * @return {function} Validator.
+ */
+function objectOfValidatorFactory(typeValidator, noWarn) {
+	return (value, name, context) => {
+		let success = true;
+
+		for (let key in value) {
+			success = typeValidator.noWarn(value[key], null);
+		}
+
+		if (!success) {
+			return warning('Expected object of one type', name, context, noWarn);
+		}
+
+		return true;
+	};
+}
+
+/**
+ * Creates a validator that checks a value against multiple types and only has to pass one.
+ * @param {!array} arrayOfTypeValidators Array of validators to check value against.
+ * @param {boolean} noWarn Determines whether warnings should be emitted.
+ * @return {function} Validator.
+ */
+function oneOfTypeValidatorFactory(arrayOfTypeValidators, noWarn) {
+	if (!Array.isArray(arrayOfTypeValidators)) {
+		warning('Expected an array.', null, null, noWarn);
+	}
+
+	return (value, name, context) => {
+		for (let i = 0; i < arrayOfTypeValidators.length; i++) {
+			const validator = arrayOfTypeValidators[i];
+
+			if (validator.noWarn(value, name)) {
+				return true;
+			}
+		}
+
+		return warning('Expected one of given types.', name, context, noWarn);
+	};
+}
+
+/**
+ * Creates a validator that checks against a specific primitive type.
+ * @param {!string} expectedType Type to check against.
+ * @param {boolean} noWarn Determines whether warnings should be emitted.
+ * @return {function} Validator.
+ */
+function primitiveTypeValidatorFactory(expectedType, noWarn) {
+	return (value, name, context) => {
+		const type = getStateType(value);
+
+		if (type !== expectedType) {
+			return warning(`Expected type ${expectedType}`, name, context, noWarn);
+		}
+
+		return true;
+	};
+}
+
+/**
+ * Creates a validator that checks the shape of an object.
+ * @param {!object} shape An object containing type validators for each key.
+ * @param {boolean} noWarn Determines whether warnings should be emitted.
+ * @return {function} Validator.
+ */
+function shapeValidatorFactory(shape, noWarn) {
+	if (getStateType(shape) !== 'object') {
+		warning(`Expected an object`, null, null, noWarn);
+	}
+
+	return (value, name, context) => {
+		for (let key in shape) {
+			const validator = shape[key];
+			const valueForKey = value[key];
+
+			if (valueForKey && !validator.noWarn(valueForKey, null)) {
+				return warning('Expected object with a specific shape', name, context, noWarn);
+			}
+		}
+
+		return true;
+	};
+}
+
+/**
+ * Creates a composed validator that checks against a certain type.
+ * @param {!string} type Type to check against.
+ * @return {function} A composed validator with both a warn and noWarn function.
+ */
+function validateType(type) {
+	return composeValidator(
+		primitiveTypeValidatorFactory,
+		type
+	);
+}
+
+/**
+ * Determines what to return and when if a warning should be emitted.
+ * @param {!string} message Error message to emit.
+ * @param {string} name Name of state key.
+ * @param {object} context.
+ * @param {boolean} noWarn Determines whether emitWarning should be run.
+ */
+function warning(message, name, context, noWarn) {
+	if (noWarn) {
+		return null;
+	} else {
+		emitWarning(message, name, context);
+	}
+
+	return true;
+}
+
+export default validators;

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,8 @@
+{
+  "mocha": true,
+  "globals": {
+    "assert": true,
+    "sinon": true
+  },
+  "extends": "../.jshintrc"
+}

--- a/test/type.js
+++ b/test/type.js
@@ -1,0 +1,201 @@
+'use strict';
+
+import typeValidators from '../src/type';
+
+describe('Type', function() {
+	beforeEach(function() {
+		sinon.stub(console, 'error');
+	});
+
+	afterEach(function() {
+		console.error.restore();
+	});
+
+	it('should validate an array', function() {
+		assert.isTrue(typeValidators.array([], null, this));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(typeValidators.array('string', null, this));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a boolean', function() {
+		assert.isTrue(typeValidators.bool(true));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(typeValidators.bool('true'));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a function', function() {
+		const testFn = function() {
+			return;
+		};
+
+		assert.isTrue(typeValidators.func(testFn));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(typeValidators.func('testFn'));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a number', function() {
+		assert.isTrue(typeValidators.number(1));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(typeValidators.number('1'));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a object', function() {
+		const obj = {};
+
+		assert.isTrue(typeValidators.object(obj));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(typeValidators.object('obj'));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a string', function() {
+		assert.isTrue(typeValidators.string('testString'));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(typeValidators.string(false));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate any type', function() {
+		typeValidators.any('testString');
+		typeValidators.any(false);
+		typeValidators.any({});
+		typeValidators.any(1);
+		typeValidators.any(function() {});
+
+		assert.isFalse(console.error.called);
+	});
+
+	it('should validate an array of a single type', function() {
+		const arrayOfNumbers = typeValidators.arrayOf(typeValidators.number);
+
+		assert.isTrue(arrayOfNumbers([1, 2, 3, 4]));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(arrayOfNumbers([1, 2, 3, '4']));
+		assert.isTrue(console.error.called);
+
+		assert.isTrue(arrayOfNumbers({}));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate an instance of a class', function() {
+		class TestClass {
+		}
+		class TestClass2 {
+		}
+
+		const instanceOfFn = typeValidators.instanceOf(TestClass);
+
+		assert.isTrue(instanceOfFn(new TestClass()));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(instanceOfFn(new TestClass2()));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate one of certain types', function() {
+		const oneOfType = typeValidators.oneOfType(
+			[
+				typeValidators.string,
+				typeValidators.number
+			]
+		);
+
+		assert.isTrue(oneOfType('test'));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(oneOfType(1));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(oneOfType({}));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should fail if an array is not supplied to oneOfType', function() {
+		typeValidators.oneOfType(
+			{
+				one: typeValidators.string
+			}
+		);
+
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate an object with certain types of values', function() {
+		const objectOf = typeValidators.objectOf(typeValidators.number);
+
+		assert.isTrue(objectOf({
+			a: 1,
+			b: 2
+		}));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(objectOf({
+			a: '1',
+			b: '2'
+		}));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a shape of an object', function() {
+		const shape = typeValidators.shape({
+			a: typeValidators.string,
+			b: typeValidators.number
+		});
+
+		assert.isTrue(shape({
+			a: '1',
+			b: 2
+		}));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(shape({
+			a: '1',
+			b: '2'
+		}));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should validate a shape nested within a shape', function() {
+		const shape = typeValidators.shape({
+			a: typeValidators.shape({
+				b: typeValidators.string
+			})
+		});
+
+		assert.isTrue(shape({
+			a: {
+				b: 'test'
+			}
+		}));
+		assert.isFalse(console.error.called);
+
+		assert.isTrue(shape({
+			a: {
+				b: 1
+			}
+		}));
+		assert.isTrue(console.error.called);
+
+		assert.isTrue(shape({
+			a: 1
+		}));
+		assert.isTrue(console.error.called);
+	});
+
+	it('should fail if an object is not supplied to shape', function() {
+		typeValidators.shape(1);
+
+		assert.isTrue(console.error.called);
+	});
+});

--- a/test/type.js
+++ b/test/type.js
@@ -3,28 +3,16 @@
 import typeValidators from '../src/type';
 
 describe('Type', function() {
-	beforeEach(function() {
-		sinon.stub(console, 'error');
-	});
-
-	afterEach(function() {
-		console.error.restore();
-	});
-
 	it('should validate an array', function() {
 		assert.isTrue(typeValidators.array([], null, this));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(typeValidators.array('string', null, this));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(typeValidators.array('string', null, this), Error);
 	});
 
 	it('should validate a boolean', function() {
 		assert.isTrue(typeValidators.bool(true));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(typeValidators.bool('true'));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(typeValidators.bool('true'), Error);
 	});
 
 	it('should validate a function', function() {
@@ -33,36 +21,28 @@ describe('Type', function() {
 		};
 
 		assert.isTrue(typeValidators.func(testFn));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(typeValidators.func('testFn'));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(typeValidators.func('testFn'), Error);
 	});
 
 	it('should validate a number', function() {
 		assert.isTrue(typeValidators.number(1));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(typeValidators.number('1'));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(typeValidators.number('1'), Error);
 	});
 
 	it('should validate a object', function() {
 		const obj = {};
 
 		assert.isTrue(typeValidators.object(obj));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(typeValidators.object('obj'));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(typeValidators.object('obj'), Error);
 	});
 
 	it('should validate a string', function() {
 		assert.isTrue(typeValidators.string('testString'));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(typeValidators.string(false));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(typeValidators.string(false), Error);
 	});
 
 	it('should validate any type', function() {
@@ -72,20 +52,16 @@ describe('Type', function() {
 		typeValidators.any(1);
 		typeValidators.any(function() {});
 
-		assert.isFalse(console.error.called);
 	});
 
 	it('should validate an array of a single type', function() {
 		const arrayOfNumbers = typeValidators.arrayOf(typeValidators.number);
 
 		assert.isTrue(arrayOfNumbers([1, 2, 3, 4]));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(arrayOfNumbers([1, 2, 3, '4']));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(arrayOfNumbers([1, 2, 3, '4']), Error);
 
-		assert.isTrue(arrayOfNumbers({}));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(arrayOfNumbers({}), Error);
 	});
 
 	it('should validate an instance of a class', function() {
@@ -97,10 +73,8 @@ describe('Type', function() {
 		const instanceOfFn = typeValidators.instanceOf(TestClass);
 
 		assert.isTrue(instanceOfFn(new TestClass()));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(instanceOfFn(new TestClass2()));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(instanceOfFn(new TestClass2()), Error);
 	});
 
 	it('should validate one of certain types', function() {
@@ -112,23 +86,20 @@ describe('Type', function() {
 		);
 
 		assert.isTrue(oneOfType('test'));
-		assert.isFalse(console.error.called);
 
 		assert.isTrue(oneOfType(1));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(oneOfType({}));
-		assert.isTrue(console.error.called);
+		assert.instanceOf(oneOfType({}), Error);
 	});
 
 	it('should fail if an array is not supplied to oneOfType', function() {
-		typeValidators.oneOfType(
+		var validator = typeValidators.oneOfType(
 			{
 				one: typeValidators.string
 			}
 		);
 
-		assert.isTrue(console.error.called);
+		assert.instanceOf(validator(), Error);
 	});
 
 	it('should validate an object with certain types of values', function() {
@@ -138,17 +109,15 @@ describe('Type', function() {
 			a: 1,
 			b: 2
 		}));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(objectOf({
+		assert.instanceOf(objectOf({
 			a: '1',
 			b: '2'
-		}));
-		assert.isTrue(console.error.called);
+		}), Error);
 	});
 
 	it('should validate a shape of an object', function() {
-		const shape = typeValidators.shape({
+		const shape = typeValidators.shapeOf({
 			a: typeValidators.string,
 			b: typeValidators.number
 		});
@@ -157,18 +126,16 @@ describe('Type', function() {
 			a: '1',
 			b: 2
 		}));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(shape({
+		assert.instanceOf(shape({
 			a: '1',
 			b: '2'
-		}));
-		assert.isTrue(console.error.called);
+		}), Error);
 	});
 
 	it('should validate a shape nested within a shape', function() {
-		const shape = typeValidators.shape({
-			a: typeValidators.shape({
+		const shape = typeValidators.shapeOf({
+			a: typeValidators.shapeOf({
 				b: typeValidators.string
 			})
 		});
@@ -178,24 +145,45 @@ describe('Type', function() {
 				b: 'test'
 			}
 		}));
-		assert.isFalse(console.error.called);
 
-		assert.isTrue(shape({
+		assert.instanceOf(shape({
 			a: {
 				b: 1
 			}
-		}));
-		assert.isTrue(console.error.called);
+		}), Error);
 
-		assert.isTrue(shape({
+		assert.instanceOf(shape({
 			a: 1
-		}));
-		assert.isTrue(console.error.called);
+		}), Error);
 	});
 
 	it('should fail if an object is not supplied to shape', function() {
-		typeValidators.shape(1);
+		const validator = typeValidators.shapeOf(1);
+		assert.instanceOf(validator(), Error);
+	});
 
-		assert.isTrue(console.error.called);
+	it('should emit warning message', function() {
+		const COMPONENT_NAME = 'componentName';
+		const NAME = 'name';
+		const PARENT_COMPONENT_NAME = 'parentComponent';
+
+		const ERROR_MESSAGE = `Error: Warning: Invalid state passed to '${NAME}'. ` +
+			`Expected type 'string' Passed to '${COMPONENT_NAME}'. Check render ` +
+			`method of '${PARENT_COMPONENT_NAME}'.`;
+
+		const context = {
+			getRenderer: function() {
+				return {
+					lastParentComponent_: {
+						name: PARENT_COMPONENT_NAME
+					}
+				};
+			},
+			name: COMPONENT_NAME
+		};
+
+		const resultError = typeValidators.string(1, NAME, context);
+
+		assert.equal(resultError, ERROR_MESSAGE);
 	});
 });


### PR DESCRIPTION
Hey @mairatma, here is an updated and more refactored version of the type validators. I generated with yo metal, so if there is anything missing just let me know

Also, as far as readability and verbose vs functional. I really tried to clean it up and make it more clear. The complexity of nested validators really forces the api to be functional and so that we can get both warning and noWarn instances of each validator. 

An example of this would be [shape](https://github.com/metal/metal-state-validators/compare/master...bryceosterhaus:type-validators?expand=1#diff-57363eb5121740bc04c5b33ea5639036R151) and [oneOfType](https://github.com/metal/metal-state-validators/compare/master...bryceosterhaus:type-validators?expand=1#diff-57363eb5121740bc04c5b33ea5639036R106)

Using this sort of api with `composeValidator` also gives us the ability to add an `isRequired` version in the future.

Let me know if that all makes sense. I still haven't added the NODE_ENV check for production yet, I wanted to run this by  you first.

Also, if you have any other ideas to add. Just let me know and I can add them.
