### PR TITLE
Get name of constructor, not of the instance.

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -155,9 +155,9 @@ const validators = {
  * @return {!Error} Instance of Error class.
  */
 function composeError(error, name, context) {
-	const componentName = context ? core.getFunctionName(context) : null;
+	const componentName = context ? core.getFunctionName(context.constructor) : null;
 	const parentComponent = context && context.getRenderer ? context.getRenderer().lastParentComponent_ : null;
-	const parentComponentName = parentComponent ? core.getFunctionName(parentComponent) : null;
+	const parentComponentName = parentComponent ? core.getFunctionName(parentComponent.constructor) : null;
 
 	const location = parentComponentName ? `Check render method of '${parentComponentName}'.` : '';
 

--- a/test/type.js
+++ b/test/type.js
@@ -195,11 +195,15 @@ describe('Type', function() {
 			getRenderer: function() {
 				return {
 					lastParentComponent_: {
-						name: PARENT_COMPONENT_NAME
+						constructor: {
+							name: PARENT_COMPONENT_NAME
+						}
 					}
 				};
 			},
-			name: COMPONENT_NAME
+			constructor: {
+				name: COMPONENT_NAME
+			}
 		};
 
 		const resultError = typeValidators.string(1, NAME, context);


### PR DESCRIPTION
We were grabbing the wrong name for the error. This fix allows the user to now know which component's state is causing the warning and also which parent component it may be nested in.
